### PR TITLE
change prompt instruction to unicode icon.

### DIFF
--- a/src/model/SearchModel.svelte
+++ b/src/model/SearchModel.svelte
@@ -296,12 +296,12 @@
 				>
 			</div>
 			<div class="prompt-instruction">
-				<span class="prompt-instruction-command">tab</span><span
+				<span class="prompt-instruction-command">⇥</span><span
 					>to close</span
 				>
 			</div>
 			<div class="prompt-instruction">
-				<span class="prompt-instruction-command">shift + tab</span><span
+				<span class="prompt-instruction-command">⇧ ⇥</span><span
 					>to close duplicate</span
 				>
 			</div>


### PR DESCRIPTION
- "tab" -> "⇥"
- "shift tab" -> "⇧ ⇥"