### PR TITLE
Add custom class to tab navigator modal

### DIFF
--- a/src/model/SearchModel.svelte
+++ b/src/model/SearchModel.svelte
@@ -284,7 +284,7 @@
 
 <div class="modal-container mod-dim">
 	<div class="modal-bg" style="opacity: 0.85;"></div>
-	<div bind:this={modalContainer} class="prompt">
+	<div bind:this={modalContainer} class="prompt tab-navigator-modal">
 		<div class="prompt-input-container">
 			<input
 				class="prompt-input"


### PR DESCRIPTION
This PR adds a custom class 'tab-navigator-modal' to the tab navigator modal element. This allows for more specific CSS targeting, so users can style the tab navigator independently from other modals that use the generic 'prompt' class. Fixes the issue where CSS styling couldn't differentiate between the tab navigator and other modals.